### PR TITLE
Refactor tests to use TestCase, add config.py

### DIFF
--- a/sponge/__init__.py
+++ b/sponge/__init__.py
@@ -1,7 +1,30 @@
 from flask import Flask
+from logging.handlers import RotatingFileHandler
+
+from sponge.config import config
+from sponge.version import __version__
+
 
 app = Flask(__name__)
 
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///sponge.db'
+app.config['SQLALCHEMY_DATABASE_URI'] = config.get('db', 'uri')
+app.config['VERSION'] = __version__
 
+if config.getboolean('main', 'propagate_exceptions'):
+    app.config['PROPAGATE_EXCEPTIONS'] = True
+
+if config.getboolean('logging', 'debug'):
+    app.debug = True
+app.logger.debug('Debug enabled')
+
+logfile = config.get('logging', 'file')
+if logfile != 'disabled':
+    handler = RotatingFileHandler(
+        logfile,
+        maxBytes=10000,
+        backupCount=1,
+    )
+    app.logger.addHandler(handler)
+
+# Must be imported last
 import sponge.views

--- a/sponge/config.py
+++ b/sponge/config.py
@@ -1,0 +1,18 @@
+from __future__ import print_function
+import ConfigParser
+__author__ = 'alforbes'
+
+config = ConfigParser.ConfigParser()
+
+config.add_section('main')
+config.add_section('db')
+config.add_section('logging')
+
+config.set('main', 'propagate_exceptions', 'true')
+
+config.set('db', 'uri', 'sqlite://')
+
+config.set('logging', 'debug', 'true')
+config.set('logging', 'file', 'disabled')
+
+config.read('/etc/sponge.ini')

--- a/sponge/orm.py
+++ b/sponge/orm.py
@@ -1,4 +1,3 @@
-# Temporary ORM layer until we can replace it with elasticsearch
 from __future__ import print_function
 
 __author__ = 'alforbes'

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -5,6 +5,29 @@ from datetime import datetime
 from orm import db, DbRelease, DbPackage, DbResults
 
 
+class InvalidUsage(Exception):
+    status_code = 400
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        rv = dict(self.payload or ())
+        rv['message'] = self.message
+        return rv
+
+
+@app.errorhandler(InvalidUsage)
+def handle_invalid_usage(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
+
 class Release:
     def __init__(self, notes, references, platforms):
         self.start = datetime.now()
@@ -20,13 +43,18 @@ class Release:
                        request.json['platforms'])
 
 
+@app.route('/ping', methods=['GET'])
+def ping():
+    return 'pong'
+
+
 @app.route('/release', methods=['POST'])
 def post_release():
     _validate_release_input(request)
     release = Release.create_from(request)
 
-    app.logger.info('Release notes: %s, references: %s, platforms: %s', release.notes, release.references,
-                    release.platforms)
+    app.logger.info('Release notes: %s, references: %s, platforms: %s',
+                    release.notes, release.references, release.platforms)
     app.logger.info('Posting release for id: %s', release.id)
 
     dbRelease = DbRelease(str(release.id), release.platforms[0], 'nobody',
@@ -40,15 +68,19 @@ def post_release():
 
 
 def _validate_release_input(request):
-    if not request.json or not 'platforms' in request.json:
-        abort(400)
+    if not request.json:
+        raise(InvalidUsage('Missing application/json header', status_code=400))
+    if 'platforms' not in request.json:
+        raise(InvalidUsage('JSON doc missing platforms field', status_code=400))
 
 
 @app.route('/release/<id>/packages', methods=['POST'])
 def post_packages(id):
     if _package_input_is_valid(request, id):
-        app.logger.info('Releasing package name: %s and version: %s, for release: %s', request.json['name'],
-                        request.json['version'], id)
+        app.logger.info(
+            'Releasing package name: %s and version: %s, for release: %s',
+            request.json['name'],
+            request.json['version'], id)
         package_id = uuid.uuid4()
         app.logger.info('Package id: %s', str(package_id))
 
@@ -79,7 +111,8 @@ def _package_input_is_valid(request, id):
     return True
 
 
-@app.route('/release/<release_id>/packages/<package_id>/results', methods=['POST'])
+@app.route('/release/<release_id>/packages/<package_id>/results',
+           methods=['POST'])
 def post_results(release_id, package_id):
     dbResults = DbResults(package_id, str(request.json))
     db.session.add(dbResults)


### PR DESCRIPTION
Did a bit of work on the tests, I found that they were failing in Vagrant and on my machine due to port conflicts. Switching to TestCase resolved it, and as a bonus removes the complexity of creating http connections.

I also switched sqlalchemy to use the in-memory sqlite database for tests, and added db initialisation to the setup, which removes the dependency of running create_db first (in-memory wouldn't actually work with LiveTestCase, as each test had an independant copy of the DB).

Also added config file, which we will need eventually :-)
