### PR TITLE
Add package start/stop endpoints

### DIFF
--- a/sponge/orm.py
+++ b/sponge/orm.py
@@ -67,7 +67,9 @@ class DbPackage(db.Model):
     stime = db.Column(db.DateTime)
     ftime = db.Column(db.DateTime)
     duration = db.Column(db.Time)
-    success = db.Column(db.Boolean)
+    status = db.Column(
+        db.Enum('NOT_STARTED', 'IN_PROGRESS', 'SUCCESSFUL', 'FAILED'),
+        default='NOT_STARTED')
     version = db.Column(db.String(16), nullable=False)
     diff_url = db.Column(db.String)
 
@@ -83,20 +85,24 @@ class DbPackage(db.Model):
 
     def start(self):
         """
-        Mark a deployment as started
+        Mark a package deployment as started
         """
         self.stime = datetime.now()
+        self.status = 'IN_PROGRESS'
 
     def stop(self, success):
         """
-        Mark a deployment as stopped
+        Mark a package deployment as stopped
         """
         self.ftime = datetime.now()
 
         if not self.duration:
             td = datetime.now() - self.stime
             self.duration = (datetime.min + td).time()
-        self.success = success
+        if success:
+            self.status = 'SUCCESSFUL'
+        else:
+            self.status = 'FAILED'
 
 
 class DbResults(db.Model):

--- a/sponge/orm.py
+++ b/sponge/orm.py
@@ -69,6 +69,7 @@ class DbPackage(db.Model):
     duration = db.Column(db.Time)
     success = db.Column(db.Boolean)
     version = db.Column(db.String(16), nullable=False)
+    diff_url = db.Column(db.String)
 
     release_id = db.Column(UUIDType, db.ForeignKey("release.id"))
     release = db.relationship("DbRelease", backref=db.backref('packages',

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -28,7 +28,7 @@ def handle_invalid_usage(error):
     return response
 
 
-def create_release(request):
+def _create_release(request):
     """
     Create a DbRelease object from a request
     """
@@ -44,11 +44,35 @@ def create_release(request):
     )
 
 
+def _create_package(release_id, request):
+    """
+    Create a package object for a release
+    """
+
+    return DbPackage(
+        release_id,
+        request.json['name'],
+        request.json['version'],
+    )
+
+
 def _validate_release_input(request):
     if not request.json:
         raise(InvalidUsage('Missing application/json header', status_code=400))
     if 'platforms' not in request.json:
         raise(InvalidUsage('JSON doc missing platforms field', status_code=400))
+
+
+def _package_input_is_valid(request, id):
+    if not request.json:
+        app.logger.error("Missing JSON body.")
+        return False
+
+    if not 'name' in request.json or not 'version' in request.json:
+        app.logger.error("Missing name / version in request body.")
+        return False
+
+    return True
 
 
 @app.route('/ping', methods=['GET'])
@@ -62,7 +86,7 @@ def post_release():
     Posting a release - the first step in a deployment
     """
     _validate_release_input(request)
-    release = create_release(request)
+    release = _create_release(request)
 
     app.logger.info('Release notes: %s, references: %s, platforms: %s',
                     release.notes, release.references, release.platforms)
@@ -78,38 +102,22 @@ def post_release():
 
 @app.route('/release/<id>/packages', methods=['POST'])
 def post_packages(id):
-    if _package_input_is_valid(request, id):
-        app.logger.info(
-            'Releasing package name: %s and version: %s, for release: %s',
-            request.json['name'],
-            request.json['version'], id)
+    if not _package_input_is_valid(request, id):
+        raise InvalidUsage("Input not valid")
 
-        dbPackage = DbPackage(
-            id,
-            request.json['name'],
-            request.json['version'],
-        )
-        app.logger.info('Package id: %s', str(dbPackage.id))
-        dbPackage.start()
-        db.session.add(dbPackage)
-        db.session.commit()
+    app.logger.info(
+        'Releasing package name: %s and version: %s, for release: %s',
+        request.json['name'],
+        request.json['version'], id)
 
-        return jsonify(id=dbPackage.id)
-    else:
-        # TODO have a proper error handler!
-        abort(400)
+    dbPackage = _create_package(id, request)
 
+    app.logger.info('Package id: %s', str(dbPackage.id))
+    dbPackage.start()
+    db.session.add(dbPackage)
+    db.session.commit()
 
-def _package_input_is_valid(request, id):
-    if not request.json:
-        app.logger.error("Missing JSON body.")
-        return False
-
-    if not 'name' in request.json or not 'version' in request.json:
-        app.logger.error("Missing name / version in request body.")
-        return False
-
-    return True
+    return jsonify(id=dbPackage.id)
 
 
 @app.route('/release/<release_id>/packages/<package_id>/results',

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -49,9 +49,10 @@ class ContractTest(SpongeTest):
         """
         response = self.client.post('/release',
             data=json.dumps({
-                'note': '',
+                'note': 'test note asdf',
                 'platforms': ['test_platform'],
                 'references': ['TestTicket-123'],
+                'team': 'Test Team',
                 'user': 'testuser',
             }),
             content_type='application/json',
@@ -86,7 +87,7 @@ class ContractTest(SpongeTest):
 
         return release_id, package_id
 
-    def test_add_results(self):
+    def test_add_package_results(self):
         """
         Add the results of a package deploy
         """
@@ -101,4 +102,31 @@ class ContractTest(SpongeTest):
             })
         )
         self.assertEqual(results_response.status_code, 204)
+
+    def test_add_release_log(self):
+        """
+        Add a log a release
+        """
+        pass
+
+    def test_set_release_success(self):
+        """
+        Set the status of a release
+
+        IN_PROGRESS, SUCCESSFUL, FAILED
+        """
+        pass
+
+    def test_create_release_optional(self):
+        """
+        Create a release, omitting all optional parameters
+        """
+        response = self.client.post('/release',
+                                    data=json.dumps({
+                                        'platforms': ['test_platform'],
+                                        'user': 'testuser',
+                                    }),
+                                    content_type='application/json',
+                                    )
+        self.assert200(response)
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -54,22 +54,20 @@ class SpongeDbTest(SpongeTest):
         """
         Test the types returned by DbRelease objects are OK
         """
-        releases = db.session.query(DbRelease).all()
-        for r in releases:
-            self.assertIs(type(r.id), uuid.UUID)
-            self.assertIs(type(r.notes), unicode)
-            self.assertIs(type(r.platforms), unicode)
-            self.assertIs(type(r.references), unicode)
-            self.assertIs(type(list(r.references)), list)
+        r = db.session.query(DbRelease).first()
+        self.assertIs(type(r.id), uuid.UUID)
+        self.assertIs(type(r.notes), unicode)
+        self.assertIs(type(r.platforms), unicode)
+        self.assertIs(type(r.references), unicode)
+        self.assertIs(type(list(r.references)), list)
 
     def test_package_types(self):
         """
         Test the types returned by DbPackage objects are OK
         """
-        packages = db.session.query(DbPackage).all()
-        for p in packages:
-            self.assertIs(type(p.id), uuid.UUID)
-            self.assertIs(type(p.name), unicode)
-            self.assertIs(type(p.stime), datetime.datetime)
-            self.assertIs(type(p.ftime), datetime.datetime)
-            self.assertIs(type(p.duration), datetime.time)
+        p = db.session.query(DbPackage).first()
+        self.assertIs(type(p.id), uuid.UUID)
+        self.assertIs(type(p.name), unicode)
+        self.assertIs(type(p.stime), datetime.datetime)
+        self.assertIs(type(p.ftime), datetime.datetime)
+        self.assertIs(type(p.duration), datetime.time)

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -71,3 +71,4 @@ class SpongeDbTest(SpongeTest):
         self.assertIs(type(p.stime), datetime.datetime)
         self.assertIs(type(p.ftime), datetime.datetime)
         self.assertIs(type(p.duration), datetime.time)
+        self.assertIs(type(p.status), unicode)


### PR DESCRIPTION
This PR adds endpoints for starting and stopping the release of a package. As part of this, the post_packages method was altered to not "start" the package, as it is not implicit that a package is started when it is created. Thus the full list of packages would be posted at the start of a release, so that they can all be displayed on a dashboard, then we indicate that each has started separately.

But this is all up to the user, there is nothing to stop someone adding each package to a release as it is done.

I also renamed "success" column to "status", and made it an Enum with specific values. Reason for the enum is enforcing a contract, rather than any sort of optimisation (our data is not likely to be large enough for this to matter).
