### PR TITLE
Add GET /releases endpoint

### DIFF
--- a/sponge/config.py
+++ b/sponge/config.py
@@ -5,13 +5,13 @@ __author__ = 'alforbes'
 config = ConfigParser.ConfigParser()
 
 config.add_section('main')
-config.add_section('db')
-config.add_section('logging')
-
 config.set('main', 'propagate_exceptions', 'true')
+config.set('main', 'time_format', '%Y-%m-%d %H:%M:%S')
 
+config.add_section('db')
 config.set('db', 'uri', 'sqlite://')
 
+config.add_section('logging')
 config.set('logging', 'debug', 'true')
 config.set('logging', 'file', 'disabled')
 

--- a/sponge/orm.py
+++ b/sponge/orm.py
@@ -18,14 +18,14 @@ class DbRelease(db.Model):
     __tablename__ = 'release'
 
     id = db.Column(UUIDType, primary_key=True, unique=True, nullable=False)
-    notes = db.Column(db.String, nullable=True)
-    platforms = db.Column(db.String)
-    references = db.Column(db.String, nullable=True)
-    stime = db.Column(db.DateTime, nullable=True)
-    ftime = db.Column(db.DateTime, nullable=True)
-    duration = db.Column(db.Interval, nullable=True)
-    user = db.Column(db.String)
-    team = db.Column(db.String, nullable=True)
+    notes = db.Column(db.String)
+    platforms = db.Column(db.String, nullable=False)
+    references = db.Column(db.String)
+    stime = db.Column(db.DateTime)
+    ftime = db.Column(db.DateTime)
+    duration = db.Column(db.Interval)
+    user = db.Column(db.String, nullable=False)
+    team = db.Column(db.String)
 
     def __init__(self, platforms, user,
                  notes=None, team=None, references=None):
@@ -84,7 +84,7 @@ class DbPackage(db.Model):
     name = db.Column(db.String(120), nullable=False)
     stime = db.Column(db.DateTime)
     ftime = db.Column(db.DateTime)
-    duration = db.Column(db.Time)
+    duration = db.Column(db.Interval)
     status = db.Column(
         db.Enum('NOT_STARTED', 'IN_PROGRESS', 'SUCCESSFUL', 'FAILED'),
         default='NOT_STARTED')
@@ -113,10 +113,9 @@ class DbPackage(db.Model):
         Mark a package deployment as stopped
         """
         self.ftime = datetime.now()
+        td = self.ftime - self.stime
+        self.duration = td
 
-        if not self.duration:
-            td = datetime.now() - self.stime
-            self.duration = (datetime.min + td).time()
         if success:
             self.status = 'SUCCESSFUL'
         else:

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -152,6 +152,7 @@ def post_releases_stop(release_id):
     """
     dbRelease = _fetch_release(release_id)
     # TODO check that all packages have been finished
+    app.logger.info("Release stop, release {}".format(release_id))
 
     dbRelease.stop()
     return '', 204

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -2,6 +2,7 @@ from sponge import app
 from sponge.exceptions import InvalidUsage
 from flask import jsonify, request, abort
 import uuid
+from collections import OrderedDict
 from datetime import datetime
 from orm import db, DbRelease, DbPackage, DbResults
 
@@ -41,18 +42,27 @@ def _create_package(release_id, request):
     )
 
 
+def _fetch_release(release_id):
+    """
+    Fetch a release by ID
+    """
+    rq = db.session.query(DbRelease).filter(DbRelease.id == release_id)
+    dbRelease = rq.first()
+    if not dbRelease:
+        raise InvalidUsage("Release does not exist")
+    return dbRelease
+
+
 def _fetch_package(release_id, package_id):
     """
     Fetch a package, and validate it is part of the release
     """
 
-    rq = db.session.query(DbRelease).filter(DbRelease.id == release_id)
+    # Fetch release first, as it is a good sanity check
+    _fetch_release(release_id)
     pq = db.session.query(DbPackage).filter(DbPackage.id == package_id)
-    dbRelease = rq.first()
     dbPackage = pq.first()
 
-    if not dbRelease:
-        raise InvalidUsage("Release does not exist")
     if not dbPackage:
         raise InvalidUsage("Package does not exist")
     if str(dbPackage.release_id) != release_id:
@@ -90,9 +100,10 @@ def post_releases():
     _validate_release_input(request)
     release = _create_release(request)
 
-    app.logger.info('Release notes: %s, references: %s, platforms: %s',
-                    release.notes, release.references, release.platforms)
-    app.logger.info('Started release: %s', release.id)
+    app.logger.info(
+        'Create release {}, references: {}, platforms: {}'.format(
+        release.id, release.notes, release.references, release.platforms)
+    )
 
     release.start()
 
@@ -102,18 +113,21 @@ def post_releases():
     return jsonify(id=release.id)
 
 
-@app.route('/releases/<id>/packages', methods=['POST'])
-def post_packages(id):
+@app.route('/releases/<release_id>/packages', methods=['POST'])
+def post_packages(release_id):
+    """
+    Add a package to a release
+    """
     _validate_package_input(request, id)
 
+    dbRelease = _fetch_release(release_id)
+    dbPackage = _create_package(dbRelease.id, request)
+
     app.logger.info(
-        'Releasing package name: %s and version: %s, for release: %s',
-        request.json['name'],
-        request.json['version'], id)
+        'Create package {}, release {}, name {}, version {}'.format(
+            dbPackage.id, dbRelease.id, request.json['name'],
+            request.json['version']))
 
-    dbPackage = _create_package(id, request)
-
-    app.logger.info('Package id: %s', str(dbPackage.id))
     db.session.add(dbPackage)
     db.session.commit()
 
@@ -124,18 +138,34 @@ def post_packages(id):
            methods=['POST'])
 def post_results(release_id, package_id):
     dbResults = DbResults(package_id, str(request.json))
+    app.logger.info("Post results, release {}, package {}".format(
+        release_id, package_id))
     db.session.add(dbResults)
     db.session.commit()
     return '', 204
 
 
+@app.route('/releases/<release_id>/stop', methods=['POST'])
+def post_releases_stop(release_id):
+    """
+    Indicate that a release has finished
+    """
+    dbRelease = _fetch_release(release_id)
+    # TODO check that all packages have been finished
+
+    dbRelease.stop()
+    return '', 204
+
+
 @app.route('/releases/<release_id>/packages/<package_id>/start',
            methods=['POST'])
-def post_package_start(release_id, package_id):
+def post_packages_start(release_id, package_id):
     """
     Indicate that a package has started deploying
     """
     dbPackage = _fetch_package(release_id, package_id)
+    app.logger.info("Package start, release {}, package {}".format(
+        release_id, package_id))
     dbPackage.start()
 
     db.session.add(dbPackage)
@@ -145,14 +175,34 @@ def post_package_start(release_id, package_id):
 
 @app.route('/releases/<release_id>/packages/<package_id>/stop',
            methods=['POST'])
-def post_package_stop(release_id, package_id):
+def post_packages_stop(release_id, package_id):
     """
     Indicate that a package has finished deploying
     """
     success = request.json['success']
     dbPackage = _fetch_package(release_id, package_id)
+    app.logger.info("Package stop, release {}, package {}, success {}".format(
+        release_id, package_id, success))
     dbPackage.stop(success=success)
 
     db.session.add(dbPackage)
     db.session.commit()
     return '', 204
+
+
+@app.route('/releases', methods=['GET'])
+def get_releases():
+    """
+    Return a list of releases to the client, filters optional
+    """
+    rq = db.session.query(DbRelease)
+    releases = rq.all()
+    output = []
+    for r in releases:
+        output.append(r.to_dict())
+
+    return jsonify(releases=output), 200
+
+
+
+

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -32,6 +32,10 @@ class SpongeTest(TestCase):
 class ContractTest(SpongeTest):
     """
     Test the api views
+
+    Most of these are dependant on prior tests, because for example to test
+    package stop, we first need a package that has been started. Thus failures
+    in tests earlier in the workflow will cause later tests to fail as well.
     """
 
     def test_ping(self):

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -105,12 +105,6 @@ class ContractTest(SpongeTest):
         )
         self.assertEqual(results_response.status_code, 204)
 
-    def test_add_release_log(self):
-        """
-        Add a log of a release
-        """
-        release_id, package_id = self.test_create_package()
-
     def test_package_start(self):
         """
         Test starting a package
@@ -142,6 +136,23 @@ class ContractTest(SpongeTest):
         )
         self.assertEqual(results_response.status_code, 204)
 
+        # for test_release_stop
+        return release_id
+
+    def test_release_stop(self):
+        """
+        Test stopping a release
+
+        As before, calls all the others as we need a full workflow present
+        """
+        release_id = self.test_package_stop()
+        results_response = self.client.post(
+            '/releases/{}/stop'.format(release_id),
+            content_type='application/json',
+        )
+
+        self.assertEqual(results_response.status_code, 204)
+
     def test_create_release_minimal(self):
         """
         Create a release, omitting all optional parameters
@@ -155,3 +166,17 @@ class ContractTest(SpongeTest):
         )
         self.assert200(response)
 
+    def test_get_release(self):
+        """
+        Test the list of releases
+        """
+        for _ in range(0, 2):
+            self.test_release_stop()
+
+        results_response = self.client.get(
+            '/releases',
+            content_type='application/json',
+        )
+        self.assertEqual(results_response.status_code, 200)
+        r_json = json.loads(results_response.data)
+        self.assertEqual(len(r_json['releases']), 2)

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -60,6 +60,10 @@ class SpongeDbTest(SpongeTest):
         self.assertIs(type(r.platforms), unicode)
         self.assertIs(type(r.references), unicode)
         self.assertIs(type(list(r.references)), list)
+        self.assertIs(type(r.stime), datetime.datetime)
+        self.assertIs(type(r.ftime), datetime.datetime)
+        self.assertIs(type(r.duration), datetime.timedelta)
+        self.assertIs(type(r.team), unicode)
 
     def test_package_types(self):
         """
@@ -70,5 +74,6 @@ class SpongeDbTest(SpongeTest):
         self.assertIs(type(p.name), unicode)
         self.assertIs(type(p.stime), datetime.datetime)
         self.assertIs(type(p.ftime), datetime.datetime)
-        self.assertIs(type(p.duration), datetime.time)
+        self.assertIs(type(p.duration), datetime.timedelta)
         self.assertIs(type(p.status), unicode)
+        self.assertIs(type(p.version), unicode)


### PR DESCRIPTION
Bit of a large one, as writing this revealed a few flaws.
- Changed duration to Interval type, which is more appropriate than Time
- Added config for time_format, which defines how timestamps are formatted
- Add a to_dict method for DbRelease, and `__str__`, which allows `str()` calls
- Added `_fetch_release` method to views.py
- Change `_fetch_package` to use `_fetch_release` as sanity (DRY)
- Tidied up logging in some of the post methods to be more consistent
- Added post_releases_stop method. Users may not want to assume the last package finish is the release finish, and it is useful as a sanity check and opportunity to clean up
- And of course, add `get_releases` function with a simple test
