### PR TITLE
Implement filters for GET /releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='sponge',
       packages=find_packages(),
       include_package_data=True,
       install_requires=[
+              'arrow',
               'Flask',
               'Flask-SQLAlchemy',
               'Flask-Testing',

--- a/sponge/config.py
+++ b/sponge/config.py
@@ -6,7 +6,7 @@ config = ConfigParser.ConfigParser()
 
 config.add_section('main')
 config.set('main', 'propagate_exceptions', 'true')
-config.set('main', 'time_format', '%Y-%m-%dT%H:%M:%S.000Z')
+config.set('main', 'time_format', '%Y-%m-%dT%H:%M:%SZ')
 config.set('main', 'time_zone', 'UTC')
 
 config.add_section('db')

--- a/sponge/orm.py
+++ b/sponge/orm.py
@@ -1,10 +1,11 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 __author__ = 'alforbes'
 from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy_utils.types.uuid import UUIDType
 
 from sponge import app, config
+from sponge.util import string_to_list
 from datetime import datetime, timedelta
 import pytz
 import uuid
@@ -40,6 +41,7 @@ class DbRelease(db.Model):
 
     def __init__(self, platforms, user,
                  notes=None, team=None, references=None):
+        # platforms and references are stored as strings in DB but really are lists
         self.id = uuid.uuid4()
         self.platforms = str(platforms)
         self.user = user
@@ -62,8 +64,8 @@ class DbRelease(db.Model):
         return {
             'id': unicode(self.id),
             'packages': [p.to_dict() for p in self.packages],
-            'platforms': self.platforms,
-            'references': self.references,
+            'platforms': string_to_list(self.platforms),
+            'references': string_to_list(self.references),
             'stime': self.stime.strftime(time_format) if self.stime else None,
             'ftime': self.ftime.strftime(time_format) if self.ftime else None,
             'duration': self.duration.seconds if self.duration else None,

--- a/sponge/util.py
+++ b/sponge/util.py
@@ -1,0 +1,37 @@
+from __future__ import print_function, unicode_literals
+import json
+
+__author__ = 'alforbes'
+
+
+def string_to_list(string):
+    """
+    Load a list from a string
+
+    :param string:
+    :return:
+    """
+    if string is None:
+        return []
+
+    if '[' in string and \
+            ']' in string and \
+            ('"' in string or "'" in string):
+        # Valid list syntax, presumably
+        return json.loads(string.replace("'", '"'))
+    else:
+        # assume just one item
+        return [string]
+
+
+def list_to_string(array):
+    """
+    Convert a list to a string for storage in the DB
+
+    :param array:
+    :return:
+    """
+    if not array:
+        return []
+
+    return '["' + '", "'.join(array) + '"]'

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -1,9 +1,8 @@
 from sponge import app
+from sponge.config import config
 from sponge.exceptions import InvalidUsage
 from flask import jsonify, request, abort
-import uuid
-from collections import OrderedDict
-from datetime import datetime
+import arrow
 from orm import db, DbRelease, DbPackage, DbResults
 from sponge.util import list_to_string
 
@@ -215,6 +214,9 @@ def get_releases():
         query = query.filter(
             DbRelease.platforms.like('%{}%'.format(request.args['platform']))
         )
+    if 'stime_before' in request.args:
+        t = arrow.get(request.args['stime_before'])
+        query = query.filter(DbRelease.stime < t)
 
     releases = query.all()
     app.logger.debug("Returning {} releases".format(len(releases)))

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -200,6 +200,8 @@ def get_releases():
 
     if 'package_name' in request.args:
         query = query.join(DbPackage).filter(DbPackage.name == request.args['package_name'])
+    if 'user' in request.args:
+        query = query.filter(DbRelease.user == request.args['user'])
 
     releases = query.all()
     output = []

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -216,7 +216,10 @@ def get_releases():
         )
     if 'stime_before' in request.args:
         t = arrow.get(request.args['stime_before'])
-        query = query.filter(DbRelease.stime < t)
+        query = query.filter(DbRelease.stime <= t)
+    if 'stime_after' in request.args:
+        t = arrow.get(request.args['stime_after'])
+        query = query.filter(DbRelease.stime >= t)
 
     releases = query.all()
     app.logger.debug("Returning {} releases".format(len(releases)))

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -220,6 +220,12 @@ def get_releases():
     if 'stime_after' in request.args:
         t = arrow.get(request.args['stime_after'])
         query = query.filter(DbRelease.stime >= t)
+    if 'ftime_before' in request.args:
+        t = arrow.get(request.args['ftime_before'])
+        query = query.filter(DbRelease.ftime <= t)
+    if 'ftime_after' in request.args:
+        t = arrow.get(request.args['ftime_after'])
+        query = query.filter(DbRelease.ftime >= t)
 
     releases = query.all()
     app.logger.debug("Returning {} releases".format(len(releases)))

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -233,6 +233,8 @@ def get_releases():
     if 'duration_greater' in request.args:
         td = datetime.timedelta(seconds=int(request.args['duration_greater']))
         query = query.filter(DbRelease.duration > td)
+    if 'team' in request.args:
+        query = query.filter(DbRelease.team == request.args['team'])
 
     releases = query.all()
     app.logger.debug("Returning {} releases".format(len(releases)))

--- a/sponge/views.py
+++ b/sponge/views.py
@@ -3,6 +3,7 @@ from sponge.config import config
 from sponge.exceptions import InvalidUsage
 from flask import jsonify, request, abort
 import arrow
+import datetime
 from orm import db, DbRelease, DbPackage, DbResults
 from sponge.util import list_to_string
 
@@ -226,6 +227,12 @@ def get_releases():
     if 'ftime_after' in request.args:
         t = arrow.get(request.args['ftime_after'])
         query = query.filter(DbRelease.ftime >= t)
+    if 'duration_less' in request.args:
+        td = datetime.timedelta(seconds=int(request.args['duration_less']))
+        query = query.filter(DbRelease.duration < td)
+    if 'duration_greater' in request.args:
+        td = datetime.timedelta(seconds=int(request.args['duration_greater']))
+        query = query.filter(DbRelease.duration > td)
 
     releases = query.all()
     app.logger.debug("Returning {} releases".format(len(releases)))

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -430,4 +430,19 @@ class GetContractTest(SpongeTest):
         """
         Filter on releases that a team was responsible for
         """
-        pass
+        for _ in range(0, 3):
+            self._create_release(team='firstTeam')
+
+        for _ in range(0, 2):
+            self._create_release(team='secondTeam')
+
+        first_results = self._get_releases(filters=['team=firstTeam'])
+        second_results = self._get_releases(filters=['team=secondTeam'])
+
+        self.assertEqual(len(first_results['releases']), 3)
+        self.assertEqual(len(second_results['releases']), 2)
+
+        for r in first_results['releases']:
+            self.assertEqual(r['team'], 'firstTeam')
+        for r in second_results['releases']:
+            self.assertEqual(r['team'], 'secondTeam')

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -358,7 +358,19 @@ class GetContractTest(SpongeTest):
         """
         Filter on releases that started after a particular time
         """
-        pass
+        for _ in range(0, 3):
+            self._create_release()
+
+        t_format = config.get('main', 'time_format')
+        now = datetime.utcnow()
+        tomorrow = (now + timedelta(days=1)).strftime(t_format)
+        yesterday = (now - timedelta(days=1)).strftime(t_format)
+
+        r_tomorrow = self._get_releases(filters=['stime_after={}'.format(tomorrow)])
+        r_yesterday = self._get_releases(filters=['stime_after={}'.format(yesterday)])
+
+        self.assertEqual(0, len(r_tomorrow['releases']))
+        self.assertEqual(3, len(r_yesterday['releases']))
 
     def test_get_release_filter_ftime_before(self):
         """

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,9 +1,11 @@
 from __future__ import print_function, unicode_literals
+from datetime import datetime, timedelta
 import sponge
 import json
 import uuid
 from flask.ext.testing import TestCase
 from sponge.orm import db
+from sponge.config import config
 
 
 class SpongeTest(TestCase):
@@ -245,6 +247,7 @@ class GetContractTest(SpongeTest):
         else:
             path = '/releases'
 
+        print("GET {}".format(path))
         results_response = self.client.get(
             path, content_type='application/json',
         )
@@ -337,7 +340,19 @@ class GetContractTest(SpongeTest):
         """
         Filter on releases that started before a particular time
         """
-        pass
+        for _ in range(0, 3):
+            self._create_release()
+
+        t_format = config.get('main', 'time_format')
+        now = datetime.utcnow()
+        tomorrow = (now + timedelta(days=1)).strftime(t_format)
+        yesterday = (now - timedelta(days=1)).strftime(t_format)
+
+        r_tomorrow = self._get_releases(filters=['stime_before={}'.format(tomorrow)])
+        r_yesterday = self._get_releases(filters=['stime_before={}'.format(yesterday)])
+
+        self.assertEqual(3, len(r_tomorrow['releases']))
+        self.assertEqual(0, len(r_yesterday['releases']))
 
     def test_get_release_filter_stime_after(self):
         """

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import sponge
 import json
 import uuid
@@ -32,15 +32,15 @@ class SpongeTest(TestCase):
     def _create_release(self,
                         user='testuser',
                         team='test team',
-                        platform='test_platform',
-                        reference='TestTicket-123',
+                        platforms='test_platform',
+                        references='TestTicket-123',
                         ):
         """
         Create a release using the REST API
 
         :param user:
         :param team:
-        :param platform:
+        :param platforms:
         :param reference:
         :return: the release ID
         """
@@ -49,8 +49,8 @@ class SpongeTest(TestCase):
             '/releases',
             data=json.dumps({
                 'note': 'test note lorem ipsum',
-                'platforms': [platform],
-                'references': [reference],
+                'platforms': platforms,
+                'references': references,
                 'team': team,
                 'user': user,
             }),
@@ -301,7 +301,6 @@ class GetContractTest(SpongeTest):
 
         first_results = self._get_releases(filters=['user=firstUser'])
         second_results = self._get_releases(filters=['user=secondUser'])
-        all_results = self._get_releases()
 
         self.assertEqual(len(first_results['releases']), 3)
         self.assertEqual(len(second_results['releases']), 2)
@@ -315,7 +314,24 @@ class GetContractTest(SpongeTest):
         """
         Filter on releases that were on a particular platform
         """
-        pass
+        for _ in range(0, 3):
+            self._create_release(platforms='firstPlatform')
+
+        for _ in range(0, 2):
+            self._create_release(platforms=['firstPlatform', 'secondPlatform'])
+
+        first_results = self._get_releases(filters=['platform=firstPlatform'])
+        second_results = self._get_releases(filters=['platform=secondPlatform'])
+
+        # Should be all releases
+        self.assertEqual(len(first_results['releases']), 5)
+        # Just those that contain "secondPlatform"
+        self.assertEqual(len(second_results['releases']), 2)
+
+        for r in first_results['releases']:
+            self.assertIn('firstPlatform', r['platforms'])
+        for r in second_results['releases']:
+            self.assertIn('secondPlatform', r['platforms'])
 
     def test_get_release_filter_stime_before(self):
         """

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -400,14 +400,31 @@ class GetContractTest(SpongeTest):
     def test_get_release_filter_duration_less(self):
         """
         Filter on releases that took less than x seconds
+
+        All releases take a very small amount of time in our tests,
+        but all should be <10 and >0 at least!
         """
-        pass
+        for _ in range(0, 3):
+            self._create_finished_release()
+
+        r = self._get_releases(filters=['duration_less=10'])
+        self.assertEqual(3, len(r['releases']))
+
+        r = self._get_releases(filters=['duration_less=0'])
+        self.assertEqual(0, len(r['releases']))
 
     def test_get_release_filter_duration_greater(self):
         """
         Filter on releases that took greater than x seconds
         """
-        pass
+        for _ in range(0, 3):
+            self._create_finished_release()
+
+        r = self._get_releases(filters=['duration_greater=10'])
+        self.assertEqual(0, len(r['releases']))
+
+        r = self._get_releases(filters=['duration_greater=0'])
+        self.assertEqual(3, len(r['releases']))
 
     def test_get_release_filter_team(self):
         """

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -235,7 +235,7 @@ class GetContractTest(SpongeTest):
     Test the HTTP GET contract
     """
 
-    def _get_release(self, filters=None):
+    def _get_releases(self, filters=None):
         """
         Perform a GET to /releases with optional filters
         """
@@ -266,7 +266,7 @@ class GetContractTest(SpongeTest):
         """
         for _ in range(0, 3):
             self._create_finished_release()
-        results = self._get_release()
+        results = self._get_releases()
         self.assertEqual(len(results['releases']), 3)
 
     def test_get_release_filter_package(self):
@@ -278,7 +278,7 @@ class GetContractTest(SpongeTest):
 
         release_id = self._create_release()
         package_id = self._create_package(release_id, name='specific-package')
-        results = self._get_release(filters=[
+        results = self._get_releases(filters=[
             'package_name=specific-package'
             ])
 
@@ -293,7 +293,23 @@ class GetContractTest(SpongeTest):
         """
         Filter on releases that were performed by a user
         """
-        pass
+        for _ in range(0, 3):
+            self._create_release(user='firstUser')
+
+        for _ in range(0, 2):
+            self._create_release(user='secondUser')
+
+        first_results = self._get_releases(filters=['user=firstUser'])
+        second_results = self._get_releases(filters=['user=secondUser'])
+        all_results = self._get_releases()
+
+        self.assertEqual(len(first_results['releases']), 3)
+        self.assertEqual(len(second_results['releases']), 2)
+
+        for r in first_results['releases']:
+            self.assertEqual(r['user'], 'firstUser')
+        for r in second_results['releases']:
+            self.assertEqual(r['user'], 'secondUser')
 
     def test_get_release_filter_platform(self):
         """

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -3,6 +3,7 @@ from tests.test_contract import SpongeTest
 from random import randrange
 from tests.test_contract import db
 from sponge.orm import DbRelease, DbPackage, DbResults
+import arrow
 import datetime
 import uuid
 
@@ -60,11 +61,10 @@ class SpongeDbTest(SpongeTest):
         self.assertIs(type(r.platforms), unicode)
         self.assertIs(type(r.references), unicode)
         self.assertIs(type(list(r.references)), list)
-        self.assertIs(type(r.stime), datetime.datetime)
-        self.assertIs(type(r.ftime), datetime.datetime)
+        self.assertIs(type(r.stime), arrow.arrow.Arrow)
+        self.assertIs(type(r.ftime), arrow.arrow.Arrow)
         self.assertIs(type(r.duration), datetime.timedelta)
         self.assertIs(type(r.team), unicode)
-        self.assertIs(type(r.timezone), unicode)
 
     def test_package_types(self):
         """
@@ -73,11 +73,8 @@ class SpongeDbTest(SpongeTest):
         p = db.session.query(DbPackage).first()
         self.assertIs(type(p.id), uuid.UUID)
         self.assertIs(type(p.name), unicode)
-        self.assertIs(type(p.stime), datetime.datetime)
-        self.assertIs(type(p.ftime), datetime.datetime)
+        self.assertIs(type(p.stime), arrow.arrow.Arrow)
+        self.assertIs(type(p.ftime), arrow.arrow.Arrow)
         self.assertIs(type(p.duration), datetime.timedelta)
         self.assertIs(type(p.status), unicode)
         self.assertIs(type(p.version), unicode)
-        self.assertIs(type(p.timezone), unicode)
-
-        self.assertEqual(p.timezone, 'UTC')


### PR DESCRIPTION
This PR implements the filters for http GET requests to /releases.

The native python datetime/time objects were dropped in favour of Arrow, which has a sqlalchemy type provided by sqlalchemy-utils.
