### PR TITLE
Refinements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,7 +74,7 @@ Vagrant.configure(2) do |config|
     sudo apt-get -y install python-pip python-dev postgresql postgresql-server-dev-all
 
     # Build tools
-    sudo apt-get -y install build-essential git-buildpackages debhelper python-dev
+    sudo apt-get -y install build-essential git-buildpackage debhelper python-dev
 
     sudo pip install --upgrade pip
     sudo pip install sphinx sphinxcontrib-httpdomain

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+python-orlo (0.0.2) stable; urgency=medium
+
+  * Update readme post-rename
+  * Update documentation post-rename
+  * Add sphinxcontrib-httpdomain for readthedocs build
+  * Add requirements for readthedocs
+  * Add docs badge
+  * Remove circular reference
+  * Add host and port arguments to run_server
+  * Add diff_url to DbPackage initialisation
+  * Move Flask-Testing to tests_require
+  * Remove binary test db file
+  * Add /import endpoint for importing historical data
+  * Add rollback parameter to package
+  * Remove runserver command from travis, not needed
+  * Remove binary test db
+  * Fix runserver port type
+  * Bump version to 0.0.2
+
+ -- Alex Forbes <alforbes@ebay.com>  Tue, 24 Nov 2015 20:00:56 +0000
+
 python-orlo (0.0.1) stable; urgency=medium
 
   [ Alex Forbes ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+python-orlo (0.0.3) stable; urgency=medium
+
+  * Multiple changes
+  * Convert platforms field to table reference, make import accept list
+  * Make platform.name unique
+
+ -- Alex Forbes <alforbes@gumtree.com>  Wed, 09 Dec 2015 16:13:44 +0000
+
 python-orlo (0.0.2) stable; urgency=medium
 
   * Update readme post-rename

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Standards-Version: 3.9.5
 Package: python-orlo
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}
-Description: A simple Flask app that can listen on any port and return arbitrary strings
+Description: An API for tracking deployments, written with Python, Flask and SqlAlchemy.
 
 

--- a/orlo/orm.py
+++ b/orlo/orm.py
@@ -202,7 +202,7 @@ class Platform(db.Model):
     __tablename__ = 'platform'
 
     id = db.Column(UUIDType, primary_key=True, unique=True)
-    name = db.Column(db.Text, nullable=False)
+    name = db.Column(db.Text, nullable=False, unique=True)
 
     def __init__(self, name):
         self.id = uuid.uuid4()

--- a/orlo/route_import.py
+++ b/orlo/route_import.py
@@ -24,34 +24,37 @@ def get_import():
     return jsonify(message=msg), 200
 
 
-@app.route('/import/release', methods=['POST'])
+@app.route('/releases/import', methods=['POST'])
 def post_import():
     """
     Import a release
 
-    The document must describe a full release, example:
-    {
-        'notes': ['note1', 'note2'],
-        'platforms': ['test_platform'],
-        'ftime': '2015-11-18T19:21:12Z',
-        'stime': '2015-11-18T19:21:12Z',
-        'team': 'test team',
-        'references': ['TestTicket-123'],
-        'packages': [
-            {
-                'status': 'SUCCESSFUL',
-                'name': 'test-package',
-                'version': '1.2.3',
-                'ftime': '2015-11-18T19:21:12Z',
-                'stime': '2015-11-18T19:21:12Z',
-                'rollback': 'false',
-                'diff_url': None,
-            }
-        ],
-        'user': 'testuser'
-    }
+    The document must contain a list of full releases, example:
+    [
+        {
+            'ftime': '2015-11-18T19:21:12Z',
+            'notes': ['note1', 'note2'],
+            'packages': [
+                {
+                    'diff_url': None,
+                    'ftime': '2015-11-18T19:21:12Z',
+                    'name': 'test-package',
+                    'rollback': 'false',
+                    'status': 'SUCCESSFUL',
+                    'stime': '2015-11-18T19:21:12Z',
+                    'version': '1.2.3',
+                }
+            ],
+            'platforms': ['test_platform'],
+            'references': ['TestTicket-123'],
+            'stime': '2015-11-18T19:21:12Z',
+            'team': 'test team',
+            'user': 'testuser'
+        },
+        {...}
+    ]
 
-    :status 200: The release was accepted
+    :status 200: The document was accepted
     """
 
     _validate_request_json(request)
@@ -110,5 +113,4 @@ def post_import():
         releases.append(release.id)
 
     return jsonify({'releases': [str(x) for x in releases]}), 200
-
 

--- a/orlo/views.py
+++ b/orlo/views.py
@@ -1,10 +1,9 @@
 from orlo import app
-from orlo.config import config
 from orlo.exceptions import InvalidUsage
 from flask import jsonify, request, abort
 import arrow
 import datetime
-from orm import db, DbRelease, DbPackage, DbResults
+from orm import db, Release, Package, PackageResult, ReleaseNote
 from orlo.util import list_to_string
 
 
@@ -15,9 +14,16 @@ def handle_invalid_usage(error):
     return response
 
 
+@app.errorhandler(400)
+def handle_400(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
+
 def _create_release(request):
     """
-    Create a DbRelease object from a request
+    Create a Release object from a request
     """
 
     references = request.json.get('references', [])
@@ -28,15 +34,15 @@ def _create_release(request):
     if platforms and type(platforms) is list:
         platforms = list_to_string(platforms)
 
-    return DbRelease(
+    release = Release(
         # Required attributes
         platforms=platforms,
         user=request.json['user'],
         # Not required
-        notes=request.json.get('notes'),
         team=request.json.get('team'),
         references=references,
     )
+    return release
 
 
 def _create_package(release_id, request):
@@ -44,7 +50,7 @@ def _create_package(release_id, request):
     Create a package object for a release
     """
 
-    return DbPackage(
+    return Package(
         release_id,
         request.json.get('name'),
         request.json.get('version'),
@@ -57,11 +63,11 @@ def _fetch_release(release_id):
     """
     Fetch a release by ID
     """
-    rq = db.session.query(DbRelease).filter(DbRelease.id == release_id)
-    dbRelease = rq.first()
-    if not dbRelease:
+    rq = db.session.query(Release).filter(Release.id == release_id)
+    release = rq.first()
+    if not release:
         raise InvalidUsage("Release does not exist")
-    return dbRelease
+    return release
 
 
 def _fetch_package(release_id, package_id):
@@ -71,15 +77,15 @@ def _fetch_package(release_id, package_id):
 
     # Fetch release first, as it is a good sanity check
     _fetch_release(release_id)
-    pq = db.session.query(DbPackage).filter(DbPackage.id == package_id)
-    dbPackage = pq.first()
+    pq = db.session.query(Package).filter(Package.id == package_id)
+    package = pq.first()
 
-    if not dbPackage:
+    if not package:
         raise InvalidUsage("Package does not exist")
-    if str(dbPackage.release_id) != release_id:
+    if str(package.release_id) != release_id:
         raise InvalidUsage("This package does not belong to this release")
 
-    return dbPackage
+    return package
 
 
 def _validate_request_json(request):
@@ -155,6 +161,10 @@ def post_releases():
     _validate_release_input(request)
     release = _create_release(request)
 
+    if request.json.get('note'):
+        release_note = ReleaseNote(release.id, request.json.get('note'))
+        db.session.add(release_note)
+
     app.logger.info(
         'Create release {}, references: {}, platforms: {}'.format(
             release.id, release.notes, release.references, release.platforms)
@@ -192,18 +202,18 @@ def post_packages(release_id):
     """
     _validate_package_input(request, release_id)
 
-    dbRelease = _fetch_release(release_id)
-    dbPackage = _create_package(dbRelease.id, request)
+    release = _fetch_release(release_id)
+    package = _create_package(release.id, request)
 
     app.logger.info(
         'Create package {}, release {}, name {}, version {}'.format(
-            dbPackage.id, dbRelease.id, request.json['name'],
+            package.id, release.id, request.json['name'],
             request.json['version']))
 
-    db.session.add(dbPackage)
+    db.session.add(package)
     db.session.commit()
 
-    return jsonify(id=dbPackage.id)
+    return jsonify(id=package.id)
 
 
 @app.route('/releases/<release_id>/packages/<package_id>/results',
@@ -217,10 +227,10 @@ def post_results(release_id, package_id):
     :<json string content: Free text field to store what you wish
     :status 204: Package results added successfully
     """
-    dbResults = DbResults(package_id, str(request.json))
+    results = PackageResult(package_id, str(request.json))
     app.logger.info("Post results, release {}, package {}".format(
         release_id, package_id))
-    db.session.add(dbResults)
+    db.session.add(results)
     db.session.commit()
     return '', 204
 
@@ -242,12 +252,12 @@ def post_releases_stop(release_id):
         curl -H "Content-Type: application/json" \\
         -X POST http://127.0.0.1/releases/${RELEASE_ID}/stop
     """
-    dbRelease = _fetch_release(release_id)
+    release = _fetch_release(release_id)
     # TODO check that all packages have been finished
     app.logger.info("Release stop, release {}".format(release_id))
-    dbRelease.stop()
+    release.stop()
 
-    db.session.add(dbRelease)
+    db.session.add(release)
     db.session.commit()
     return '', 204
 
@@ -268,12 +278,12 @@ def post_packages_start(release_id, package_id):
 
         curl -X POST http://127.0.0.1/releases/${RELEASE_ID}/packages/${PACKAGE_ID}/start
     """
-    dbPackage = _fetch_package(release_id, package_id)
+    package = _fetch_package(release_id, package_id)
     app.logger.info("Package start, release {}, package {}".format(
         release_id, package_id))
-    dbPackage.start()
+    package.start()
 
-    db.session.add(dbPackage)
+    db.session.add(package)
     db.session.commit()
     return '', 204
 
@@ -291,16 +301,40 @@ def post_packages_stop(release_id, package_id):
         curl -H "Content-Type: application/json" \\
         -X POST http://127.0.0.1/releases/${RELEASE_ID}/packages/${PACKAGE_ID}/stop \\
         -d '{"success": "true"}'
+
+    :param string package_id: Package UUID
+    :param string release_id: Release UUID
     """
     _validate_request_json(request)
     success = request.json['success']
 
-    dbPackage = _fetch_package(release_id, package_id)
+    package = _fetch_package(release_id, package_id)
     app.logger.info("Package stop, release {}, package {}, success {}".format(
         release_id, package_id, success))
-    dbPackage.stop(success=success)
+    package.stop(success=success)
 
-    db.session.add(dbPackage)
+    db.session.add(package)
+    db.session.commit()
+    return '', 204
+
+
+@app.route('/releases/<release_id>/notes', methods=['POST'])
+def post_releases_notes(release_id):
+    """
+    Add a note to a release
+
+    :param string release_id: Release UUID
+    :param string text: Text
+    :return:
+    """
+    _validate_request_json(request)
+    text = request.json.get('text')
+    if not text:
+        raise InvalidUsage("Must include text in posted document")
+
+    note = ReleaseNote(release_id, text)
+    app.logger.info("Adding note to release {}".format(release_id))
+    db.session.add(note)
     db.session.commit()
     return '', 204
 
@@ -328,38 +362,38 @@ def get_releases(release_id=None):
 
     .. versionadded:: 0.0.1
     """
-    query = db.session.query(DbRelease).order_by(DbRelease.stime.asc())
+    query = db.session.query(Release).order_by(Release.stime.asc())
 
     if release_id:
-        query = query.filter(DbRelease.id == release_id)
+        query = query.filter(Release.id == release_id)
     if 'package_name' in request.args:
-        query = query.join(DbPackage).filter(DbPackage.name == request.args['package_name'])
+        query = query.join(Package).filter(Package.name == request.args['package_name'])
     if 'user' in request.args:
-        query = query.filter(DbRelease.user == request.args['user'])
+        query = query.filter(Release.user == request.args['user'])
     if 'platform' in request.args:
         query = query.filter(
-            DbRelease.platforms.like('%{}%'.format(request.args['platform']))
+            Release.platforms.like('%{}%'.format(request.args['platform']))
         )
     if 'stime_before' in request.args:
         t = arrow.get(request.args['stime_before'])
-        query = query.filter(DbRelease.stime <= t)
+        query = query.filter(Release.stime <= t)
     if 'stime_after' in request.args:
         t = arrow.get(request.args['stime_after'])
-        query = query.filter(DbRelease.stime >= t)
+        query = query.filter(Release.stime >= t)
     if 'ftime_before' in request.args:
         t = arrow.get(request.args['ftime_before'])
-        query = query.filter(DbRelease.ftime <= t)
+        query = query.filter(Release.ftime <= t)
     if 'ftime_after' in request.args:
         t = arrow.get(request.args['ftime_after'])
-        query = query.filter(DbRelease.ftime >= t)
+        query = query.filter(Release.ftime >= t)
     if 'duration_less' in request.args:
         td = datetime.timedelta(seconds=int(request.args['duration_less']))
-        query = query.filter(DbRelease.duration < td)
+        query = query.filter(Release.duration < td)
     if 'duration_greater' in request.args:
         td = datetime.timedelta(seconds=int(request.args['duration_greater']))
-        query = query.filter(DbRelease.duration > td)
+        query = query.filter(Release.duration > td)
     if 'team' in request.args:
-        query = query.filter(DbRelease.team == request.args['team'])
+        query = query.filter(Release.team == request.args['team'])
 
     releases = query.all()
     app.logger.debug("Returning {} releases".format(len(releases)))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import multiprocessing  # nopep8
 
 setup(
     name='orlo',
-    version='0.0.2',
+    version='0.0.3',
     description='Deployment data capture API',
     author='Alex Forbes',
     author_email='alforbes@ebay.com',

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, unicode_literals
 import json
-from orlo.orm import DbRelease, DbPackage, db
+from orlo.orm import Release, Package, db
 from orlo.config import config
 from orlo.util import string_to_list
 from tests.test_contract import OrloTest
@@ -23,6 +23,7 @@ class ImportTest(OrloTest):
                 'ftime': '2015-11-18T19:21:12Z',
                 'stime': '2015-11-18T19:21:12Z',
                 'diff_url': None,
+                'rollback': False,
             }
         ],
         'user': 'testuser'
@@ -51,8 +52,8 @@ class ImportTest(OrloTest):
         )
 
         self.assert200(response)
-        self.release = db.session.query(DbRelease).first()
-        self.package = db.session.query(DbPackage).first()
+        self.release = db.session.query(Release).first()
+        self.package = db.session.query(Package).first()
 
     def test_import_param_platforms(self):
         """

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, unicode_literals
 import json
-from orlo.orm import Release, Package, db
+from orlo.orm import Release, Package, Platform, db
 from orlo.config import config
 from orlo.util import string_to_list
 from tests.test_contract import OrloTest
@@ -9,25 +9,39 @@ __author__ = 'alforbes'
 
 
 class ImportTest(OrloTest):
-    doc = {
-        'platforms': ['test_platform'],
-        'ftime': '2015-11-18T19:21:12Z',
-        'stime': '2015-11-18T19:21:12Z',
-        'team': 'test team',
-        'references': ['TestTicket-123'],
-        'packages': [
+    doc = """
+    [
+        {
+          "platforms": [ "GumtreeUK" ],
+          "ftime": "2015-12-09T12:34:45Z",
+          "stime": "2015-12-09T12:34:45Z",
+          "team": "Gumtree UK Site Operations",
+          "references": [ "GTEPICS-TEST3" ],
+          "packages": [
             {
-                'status': 'SUCCESSFUL',
-                'name': 'test-package',
-                'version': '1.2.3',
-                'ftime': '2015-11-18T19:21:12Z',
-                'stime': '2015-11-18T19:21:12Z',
-                'diff_url': None,
-                'rollback': False,
+              "status": "SUCCESSFUL",
+              "rollback": true,
+              "name": "test-package-1",
+              "version": "0.0.1",
+              "ftime": "2015-12-09T12:34:45Z",
+              "stime": "2015-12-09T12:34:45Z",
+              "diff_url": "http://example.com/diff"
+            },
+            {
+              "status": "SUCCESSFUL",
+              "rollback": true,
+              "name": "test-package-2",
+              "version": "0.0.2",
+              "ftime": "2015-12-09T12:34:45Z",
+              "stime": "2015-12-09T12:34:45Z",
+              "diff_url": null
             }
-        ],
-        'user': 'testuser'
-    }
+          ],
+          "user": "bob"
+        }
+    ]
+    """
+    doc_dict = json.loads(doc)
 
     def setUp(self):
         db.create_all()
@@ -44,22 +58,22 @@ class ImportTest(OrloTest):
         """
         Import our test document
         """
-
         response = self.client.post(
             '/import/release',
-            data=json.dumps(self.doc),
+            data=self.doc,
             content_type='application/json',
         )
 
-        self.assert200(response)
+        # self.assert200(response)
         self.release = db.session.query(Release).first()
         self.package = db.session.query(Package).first()
+        self.platform = db.session.query(Platform).first()
 
     def test_import_param_platforms(self):
         """
         Test that the platforms field is imported successfully
         """
-        self.assertEqual(self.release.platforms, unicode(self.doc['platforms']))
+        self.assertEqual(self.platform.name, self.doc_dict[0]['platforms'][0])
 
     def test_import_param_ftime(self):
         """
@@ -68,7 +82,7 @@ class ImportTest(OrloTest):
 
         self.assertEqual(
             self.release.ftime.strftime(config.get('main', 'time_format')),
-            self.doc['stime'])
+            self.doc_dict[0]['stime'])
 
     def test_import_param_stime(self):
         """
@@ -76,49 +90,49 @@ class ImportTest(OrloTest):
         """
         self.assertEqual(
             self.release.stime.strftime(config.get('main', 'time_format')),
-            self.doc['stime'])
+            self.doc_dict[0]['stime'])
 
     def test_import_param_team(self):
         """
         Test imported team matches
         """
-        self.assertEqual(self.release.team, self.doc['team'])
+        self.assertEqual(self.release.team, self.doc_dict[0]['team'])
 
     def test_import_param_references(self):
         """
         Test imported references match
         """
-        self.assertEqual(self.release.references, unicode(self.doc['references']))
+        self.assertEqual(self.release.references, unicode(self.doc_dict[0]['references']))
 
     def test_import_param_user(self):
         """
         Test import user matches
         """
-        self.assertEqual(self.release.user, unicode(self.doc['user']))
+        self.assertEqual(self.release.user, unicode(self.doc_dict[0]['user']))
 
     def test_import_param_package_status(self):
         """
         Test package status attributes match
         """
-        self.assertEqual(self.package.status, self.doc['packages'][0]['status'])
+        self.assertEqual(self.package.status, self.doc_dict[0]['packages'][0]['status'])
 
     def test_import_param_package_name(self):
         """
         Test package name attributes match
         """
-        self.assertEqual(self.package.name, self.doc['packages'][0]['name'])
+        self.assertEqual(self.package.name, self.doc_dict[0]['packages'][0]['name'])
 
     def test_import_param_package_version(self):
         """
         Test package version attributes match
         """
-        self.assertEqual(self.package.version, self.doc['packages'][0]['version'])
+        self.assertEqual(self.package.version, self.doc_dict[0]['packages'][0]['version'])
 
     def test_import_param_package_diff_url(self):
         """
-        Test package diff_url attributes match
+        Test package diff_url is recorded
         """
-        self.assertEqual(self.package.diff_url, self.doc['packages'][0]['diff_url'])
+        self.assertEqual(self.package.diff_url, self.doc_dict[0]['packages'][0]['diff_url'])
 
     def test_import_param_package_ftime(self):
         """
@@ -126,7 +140,7 @@ class ImportTest(OrloTest):
         """
         self.assertEqual(
             self.package.ftime.strftime(config.get('main', 'time_format')),
-            self.doc['packages'][0]['ftime'])
+            self.doc_dict[0]['packages'][0]['ftime'])
 
     def test_import_param_package_stime(self):
         """
@@ -134,4 +148,4 @@ class ImportTest(OrloTest):
         """
         self.assertEqual(
             self.package.stime.strftime(config.get('main', 'time_format')),
-            self.doc['packages'][0]['stime'])
+            self.doc_dict[0]['packages'][0]['stime'])

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -59,7 +59,7 @@ class ImportTest(OrloTest):
         Import our test document
         """
         response = self.client.post(
-            '/import/release',
+            '/releases/import',
             data=self.doc,
             content_type='application/json',
         )

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from tests.test_contract import OrloTest
 from random import randrange
 from tests.test_contract import db
-from orlo.orm import Release, Package, PackageResult
+from orlo.orm import Release, Package, PackageResult, Platform
 import arrow
 import datetime
 import uuid
@@ -22,9 +22,14 @@ class OrloDbTest(OrloTest):
         for _ in range(10):
             self._add_release()
 
+    def _add_platform(self):
+        p = Platform('PLATFORM1')
+        db.session.add(p)
+        return p
+
     def _add_release(self):
         r = Release(
-            platforms=['PLATFORM1', 'PLATFORM2'],
+            platforms=[self._add_platform()],
             user='TEST USER',
             references=['REF-{}'.format(randrange(99, 1000)) * 2],
             team='TEST TEAM',
@@ -57,7 +62,7 @@ class OrloDbTest(OrloTest):
         r = db.session.query(Release).first()
         self.assertIs(type(r.id), uuid.UUID)
         self.assertIs(hasattr(r.notes, '__iter__'), True)
-        self.assertIs(type(r.platforms), unicode)
+        self.assertIs(hasattr(r.platforms, '__iter__'), True)
         self.assertIs(type(r.references), unicode)
         self.assertIs(type(list(r.references)), list)
         self.assertIs(type(r.stime), arrow.arrow.Arrow)

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -18,18 +18,16 @@ class OrloDbTest(OrloTest):
     def setUp(self):
         super(OrloDbTest, self).setUp()
 
+        # Setup a platform
+        self.platform = Platform('TEST-PLATFORM')
+
         # Add 10 releases
-        for _ in range(10):
-            self._add_release()
+        for i in range(10):
+            self._add_release(i)
 
-    def _add_platform(self):
-        p = Platform('PLATFORM1')
-        db.session.add(p)
-        return p
-
-    def _add_release(self):
+    def _add_release(self, i):
         r = Release(
-            platforms=[self._add_platform()],
+            platforms=[self.platform],
             user='TEST USER',
             references=['REF-{}'.format(randrange(99, 1000)) * 2],
             team='TEST TEAM',

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from tests.test_contract import OrloTest
 from random import randrange
 from tests.test_contract import db
-from orlo.orm import DbRelease, DbPackage, DbResults
+from orlo.orm import Release, Package, PackageResult
 import arrow
 import datetime
 import uuid
@@ -23,10 +23,9 @@ class OrloDbTest(OrloTest):
             self._add_release()
 
     def _add_release(self):
-        r = DbRelease(
+        r = Release(
             platforms=['PLATFORM1', 'PLATFORM2'],
             user='TEST USER',
-            notes='Random note {}'.format(randrange(0, 1000)),
             references=['REF-{}'.format(randrange(99, 1000)) * 2],
             team='TEST TEAM',
         )
@@ -42,7 +41,7 @@ class OrloDbTest(OrloTest):
         """
         Add a package to a release
         """
-        p = DbPackage(
+        p = Package(
             release_id=release_id,
             name='TestPackage-{}'.format(randrange(0, 10)),
             version=str(randrange(0, 1000)),
@@ -53,11 +52,11 @@ class OrloDbTest(OrloTest):
 
     def test_release_types(self):
         """
-        Test the types returned by DbRelease objects are OK
+        Test the types returned by Release objects are OK
         """
-        r = db.session.query(DbRelease).first()
+        r = db.session.query(Release).first()
         self.assertIs(type(r.id), uuid.UUID)
-        self.assertIs(type(r.notes), unicode)
+        self.assertIs(hasattr(r.notes, '__iter__'), True)
         self.assertIs(type(r.platforms), unicode)
         self.assertIs(type(r.references), unicode)
         self.assertIs(type(list(r.references)), list)
@@ -68,9 +67,9 @@ class OrloDbTest(OrloTest):
 
     def test_package_types(self):
         """
-        Test the types returned by DbPackage objects are OK
+        Test the types returned by Package objects are OK
         """
-        p = db.session.query(DbPackage).first()
+        p = db.session.query(Package).first()
         self.assertIs(type(p.id), uuid.UUID)
         self.assertIs(type(p.name), unicode)
         self.assertIs(type(p.stime), arrow.arrow.Arrow)


### PR DESCRIPTION
Headliners:
- Notes is now a separate table (converting strings to lists and back proved problematic). Many to one with releases.
- Platforms is now a separate table (same reason as above), many to many relationship with releases.
- Renamed ORM classes to omit the "Db" prefix
- Releases import endpoint now accepts a list of releases
- Added a handler for 400 errors so it returns a useful message (when we don't raise InvalidUsage)
